### PR TITLE
error handling in Cymon and Xforce modules

### DIFF
--- a/modules/sfp_cymon.py
+++ b/modules/sfp_cymon.py
@@ -82,7 +82,12 @@ class sfp_cymon(SpiderFootPlugin):
 
         if res['content'] is None:
             self.sf.info("No Cymon info found for " + qry)
-            return None
+            # normally returns None, but that result is not handled in the rest of the code
+	    # other modules use "continue" if the query returns None, moving on to the next addr
+	    # but here, we can still perform other queries on the same one
+	    
+	    # returning an empty dict allows execution to continue without results
+	    return {}
 
         try:
             info = json.loads(res['content'])

--- a/modules/sfp_xforce.py
+++ b/modules/sfp_xforce.py
@@ -51,17 +51,10 @@ class sfp_xforce(SpiderFootPlugin):
 
     def xforce_gettoken(self, xforce_url):
         HOME = os.path.dirname(os.path.realpath(__file__))
-        TOKEN = self.opts['xforcetoken']
-
-        if os.path.isfile("./" + TOKEN):
-            tokenf = open(HOME + "/" + TOKEN ,"r")
-            token = tokenf.readline()
-        else:
-            data = urllib2.urlopen( xforce_url + "/auth/anonymousToken" )
-            t = json.load(data)
-            token = str(t['token'])
-            tokenf = open(HOME + "/token","w")
-            tokenf.write(token)
+        tokenf = open(HOME + "/" + TOKEN ,"r")
+        token = tokenf.readline()
+	# anonymous tokens are now deprecated
+	# handling of invalid tokens is now done in "handleEvent"
         return token
 
     def setup(self, sfc, userOpts=dict()):
@@ -97,7 +90,7 @@ class sfp_xforce(SpiderFootPlugin):
 
         xforce_url = "https://xforce-api.mybluemix.net:443"
         token = self.xforce_gettoken(xforce_url)
-        htoken = "Bearer "+ token
+	htoken = "Bearer "+ token
         headers = {'Authorization': htoken,}
         url = xforce_url + "/" + querytype + "/" + qry
         res = self.sf.fetchUrl(url , timeout=self.opts['_fetchtimeout'], useragent="SpiderFoot", headers=headers)
@@ -120,6 +113,11 @@ class sfp_xforce(SpiderFootPlugin):
         eventName = event.eventType
         srcModuleName = event.module
         eventData = event.data
+
+	TOKEN = self.opts['xforcetoken']
+	if not os.path.isfile("./" + TOKEN):
+            self.sf.error("You enabled sfp_xforce but did not specify a valid token!", False)
+            return None
 
         infield_sep = self.opts['infield_sep']
 

--- a/modules/sfp_xforce.py
+++ b/modules/sfp_xforce.py
@@ -50,6 +50,7 @@ class sfp_xforce(SpiderFootPlugin):
     results = dict()
 
     def xforce_gettoken(self, xforce_url):
+	TOKEN = self.opts['xforcetoken']
         HOME = os.path.dirname(os.path.realpath(__file__))
         tokenf = open(HOME + "/" + TOKEN ,"r")
         token = tokenf.readline()


### PR DESCRIPTION
Two small fixes that were causing errors in scans.

For Cymon, the query result was assumed to be a dictionary but could be "None".

For Xforce, the anonymous token was causing 404 errors. They are now deprecated.
From https://api.xforce.ibmcloud.com/doc/ 
"Changes are now active: Anonymous-Tokens are deprecated and are no longer valid for authentication against the API. In order to execute API requests, you will need to generate an API key and password pair here and fill it into the form above."
